### PR TITLE
Make thingsboard config query parameters lower case

### DIFF
--- a/scripts/config.php
+++ b/scripts/config.php
@@ -55,8 +55,8 @@ if(isset($_GET["latitude"])){
   $site_name = str_replace('"', "", $site_name);
   $site_name = str_replace('\'', "", $site_name);
   $birdweather_id = $_GET["birdweather_id"];
-  $thingsboard_device_token = $_GET["THINGSBOARD_DEVICE_TOKEN"]; // New Thingsboard ID
-  $thingsboard_address = $_GET["THINGSBOARD_ADDRESS"]; // New THINGSBOARD_ADDRESS
+  $thingsboard_device_token = $_GET["thingsboard_device_token"]; // New Thingsboard ID
+  $thingsboard_address = $_GET["thingsboard_address"]; // New THINGSBOARD_ADDRESS
   $apprise_input = $_GET['apprise_input'];
   $apprise_notification_title = $_GET['apprise_notification_title'];
   $apprise_notification_body = $_GET['apprise_notification_body'];

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -53,6 +53,13 @@ DATA_MODEL_VERSION=1
 
 BIRDWEATHER_ID=
 
+#---------------------  Thingsboard Station Information -----------------------#
+#_____________Setting the below variables will enable reporting to_____________#
+#__________________________________Thingsboard_________________________________#
+
+THINGSBOARD_ADDRESS=https://data.folkertdeboerecology.nl
+THINGSBOARD_DEVICE_TOKEN=
+
 #-----------------------  Web Interface User Password  ------------------------#
 #____________________The variable below sets the 'birdnet'_____________________#
 #___________________user password for the Live Audio Stream,___________________#


### PR DESCRIPTION
I believe this will fix storing the input variables: these parameters in `$_GET` need to correspond with the `name` of the input fields, e.g. [here](https://github.com/fkdeboer/BirdNET-Pi/blob/2d896b7a391153e529b426d55ca1ee2dc45062a2/scripts/config.php#L501).

Also the config fields need to be installed on the device in the conf file which is copied to `/etc/birdnet/birdnet.conf` during installation.

~~Note: I have not tested this yet~~ Now successfully tested!