### PR TITLE
Add Luistervink task processor

### DIFF
--- a/scripts/birdnet_log.sh
+++ b/scripts/birdnet_log.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
-journalctl --no-hostname -q -o short -fu birdnet_analysis -u birdnet_recording | sed "s/$(date "+%b %d ")//g;s/${HOME//\//\\/}\///g;/Line/d;/find/d;/systemd/d;s/ .*\[.*\]: /---/"
+journalctl --no-hostname -q -o short -ft luistervink \
+  | sed "s/$(date "+%b %d ")//g;s/${HOME//\//\\/}\///g;/Line/d;/find/d;/systemd/d;s/ .*\[.*\]: /---/" &
+  journalctl --no-hostname -q -o short -fu birdnet_analysis -u birdnet_recording \
+  | sed "s/$(date "+%b %d ")//g;s/${HOME//\//\\/}\///g;/Line/d;/find/d;/systemd/d;s/ .*\[.*\]: /---/"

--- a/scripts/config.php
+++ b/scripts/config.php
@@ -489,13 +489,13 @@ function runProcess() {
 	  <table class="settingstable"><tr><td>
 	    <h2>Luistervink</h2>
       <label for="luistervink_server_address">Luistervink Address: </label>
-      <input name="luistervink_server_address" type="text" value="<?php echo htmlspecialchars($config['LUISTERVINK_SERVER_ADDRESS'] ?? ''); ?>" /><br>
+      <input name="luistervink_server_address" size="35" type="text" value="<?php echo htmlspecialchars($config['LUISTERVINK_SERVER_ADDRESS'] ?? ''); ?>" /><br>
       <label for="luistervink_device_token">Device Token: </label>
-      <input name="luistervink_device_token" type="text" value="<?php print($config['LUISTERVINK_DEVICE_TOKEN']);?>" /><br>
+      <input name="luistervink_device_token" size="65" type="text" value="<?php print($config['LUISTERVINK_DEVICE_TOKEN']);?>" /><br>
       <label for="luistervink_task_processor">Enable task processor: </label>
       <select name="luistervink_task_processor" class="testbtn">
-        <option value="1" <?php if (!empty($config['LUISTERVINK_ENABLE_TASK_PROCESSOR'])) echo 'selected="selected"'; ?>>Enabled</option>
-        <option value="0" <?php if (empty($config['LUISTERVINK_ENABLE_TASK_PROCESSOR'])) echo 'selected="selected"'; ?>>Disabled</option>
+        <option value="true" <?php if (!empty($config['LUISTERVINK_ENABLE_TASK_PROCESSOR'])) echo 'selected="selected"'; ?>>Enabled</option>
+        <option value="false" <?php if (empty($config['LUISTERVINK_ENABLE_TASK_PROCESSOR'])) echo 'selected="selected"'; ?>>Disabled</option>
       </select>
          <p>Enter the Luistervink address and device token for integration with the system.</p>
       </td></tr></table><br>

--- a/scripts/config.php
+++ b/scripts/config.php
@@ -57,6 +57,7 @@ if(isset($_GET["latitude"])){
   $birdweather_id = $_GET["birdweather_id"];
   $luistervink_device_token = $_GET["luistervink_device_token"]; // New Luistervink ID
   $luistervink_server_address = $_GET["luistervink_server_address"]; // New LUISTERVINK_SERVER_ADDRESS
+  $luistervink_task_processor = $_GET["luistervink_task_processor"];
   $apprise_input = $_GET['apprise_input'];
   $apprise_notification_title = $_GET['apprise_notification_title'];
   $apprise_notification_body = $_GET['apprise_notification_body'];
@@ -140,6 +141,7 @@ if(isset($_GET["latitude"])){
   $contents = preg_replace("/BIRDWEATHER_ID=.*/", "BIRDWEATHER_ID=$birdweather_id", $contents);
   $contents = preg_replace("/LUISTERVINK_SERVER_ADDRESS=.*/", "LUISTERVINK_SERVER_ADDRESS=$luistervink_server_address", $contents);
   $contents = preg_replace("/LUISTERVINK_DEVICE_TOKEN=.*/", "LUISTERVINK_DEVICE_TOKEN=$luistervink_device_token", $contents);
+  $contents = preg_replace("/LUISTERVINK_ENABLE_TASK_PROCESSOR=.*/", "LUISTERVINK_ENABLE_TASK_PROCESSOR=$luistervink_task_processor", $contents);
   $contents = preg_replace("/APPRISE_NOTIFICATION_TITLE=.*/", "APPRISE_NOTIFICATION_TITLE=\"$apprise_notification_title\"", $contents);
   $contents = preg_replace("/APPRISE_NOTIFICATION_BODY=.*/", "APPRISE_NOTIFICATION_BODY=\"$apprise_notification_body\"", $contents);
   $contents = preg_replace("/APPRISE_NOTIFY_EACH_DETECTION=.*/", "APPRISE_NOTIFY_EACH_DETECTION=$apprise_notify_each_detection", $contents);
@@ -490,6 +492,11 @@ function runProcess() {
       <input name="luistervink_server_address" type="text" value="<?php echo htmlspecialchars($config['LUISTERVINK_SERVER_ADDRESS'] ?? ''); ?>" /><br>
       <label for="luistervink_device_token">Device Token: </label>
       <input name="luistervink_device_token" type="text" value="<?php print($config['LUISTERVINK_DEVICE_TOKEN']);?>" /><br>
+      <label for="luistervink_task_processor">Enable task processor: </label>
+      <select name="luistervink_task_processor" class="testbtn">
+        <option value="1" <?php if (!empty($config['LUISTERVINK_ENABLE_TASK_PROCESSOR'])) echo 'selected="selected"'; ?>>Enabled</option>
+        <option value="0" <?php if (empty($config['LUISTERVINK_ENABLE_TASK_PROCESSOR'])) echo 'selected="selected"'; ?>>Disabled</option>
+      </select>
          <p>Enter the Luistervink address and device token for integration with the system.</p>
       </td></tr></table><br>
     <table class="settingstable" style="width:100%"><tr><td>

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -57,8 +57,9 @@ BIRDWEATHER_ID=
 #_____________Setting the below variables will enable reporting to_____________#
 #__________________________________Luistervink_________________________________#
 
-LUISTERVINK_SERVER_ADDRESS=https://data.folkertdeboerecology.nl
+LUISTERVINK_SERVER_ADDRESS=https://api.luistervink.nl
 LUISTERVINK_DEVICE_TOKEN=
+LUISTERVINK_ENABLE_TASK_PROCESSOR=true
 
 #-----------------------  Web Interface User Password  ------------------------#
 #____________________The variable below sets the 'birdnet'_____________________#

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -386,6 +386,10 @@ install_weekly_cron() {
   sed "s/\$USER/$USER/g" $my_dir/templates/weekly_report.cron >> /etc/crontab
 }
 
+install_luistervink_cron() {
+  sed "s/\$USER/$USER/g" $my_dir/templates/luistervink.cron >> /etc/crontab
+}
+
 chown_things() {
   chown -R $USER:$USER $HOME/Bird*
 }
@@ -421,6 +425,7 @@ install_services() {
   install_birdnet_mount
   install_cleanup_cron
   install_weekly_cron
+  install_luistervink_cron
   increase_caddy_timeout
 
   create_necessary_dirs

--- a/scripts/luistervink/client.py
+++ b/scripts/luistervink/client.py
@@ -1,0 +1,28 @@
+import requests
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class LuistervinkClient:
+    def __init__(self, conf: dict):
+        self.conf = conf
+        self.base_url = conf.get(
+            "LUISTERVINK_SERVER_ADDRESS", "https://api.luistervink.nl"
+        )
+        self.params = {"token": conf.get("LUISTERVINK_DEVICE_TOKEN")}
+        self.session = requests.Session()
+
+    def get(self, endpoint: str) -> requests.Response:
+        url = f"{self.base_url}/api/{endpoint}"
+        return requests.get(url, params=self.params)
+
+    def post(
+        self, endpoint: str, data: dict | None = None, files: dict | None = None
+    ) -> requests.Response:
+        url = f"{self.base_url}/{endpoint}"
+        return requests.post(url, json=data, params=self.params, files=files)
+
+    def put(self, endpoint: str, data: dict | None = None) -> requests.Response:
+        url = f"{self.base_url}/{endpoint}"
+        return requests.put(url, json=data, params=self.params)

--- a/scripts/luistervink/dto.py
+++ b/scripts/luistervink/dto.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Task:
+    type: str
+    spec: Any

--- a/scripts/luistervink/handler.py
+++ b/scripts/luistervink/handler.py
@@ -1,0 +1,96 @@
+import os
+import sqlite3
+import logging
+from datetime import datetime, timezone
+from tzlocal import get_localzone
+
+from luistervink.client import LuistervinkClient
+from utils.helpers import DB_PATH, HOME_DIR
+
+log = logging.getLogger(__name__)
+
+
+class BaseHandler:
+    type: str
+
+    def __init__(self, client: LuistervinkClient, spec: dict | str) -> None:
+        self.client = client
+        self.spec = spec
+
+    def handle(self) -> str:
+        """Handle the task and return a result."""
+        raise NotImplementedError("Subclasses should implement this method.")
+
+
+class DetectionSoundHandler(BaseHandler):
+    type: str = "sound_request"
+    spec: dict
+
+    def handle(self) -> str:
+        filepath = self._find_detection_filename()
+        if filepath is None:
+            log.warning("No detection found for the given spec.")
+            return self._handle_no_sound("Detection not found")
+
+        if not os.path.exists(filepath):
+            log.error(f"Detection file does not exist: {filepath}")
+            return self._handle_no_sound("Sound file not available")
+
+        log.info(f"Found detection file: {filepath}")
+        return self._handle_sound(filepath)
+
+    def _find_detection_filename(self) -> str | None:
+        """Find a detection in the database based on the spec."""
+        scientific_name = self.spec.get("scientific_name")
+        confidence = self.spec.get("confidence")
+
+        utc_dt = datetime.strptime(
+            self.spec["timestamp"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=timezone.utc)
+        local_tz = utc_dt.astimezone(get_localzone())
+
+        date = local_tz.strftime("%Y-%m-%d")
+        time = local_tz.strftime("%H:%M:%S")
+
+        con = sqlite3.connect(DB_PATH)
+        cur = con.cursor()
+
+        sql = f"""SELECT Date, Com_Name, File_Name FROM detections
+            WHERE Date = DATE('{date}')
+            AND Time = TIME('{time}')
+            AND Sci_Name = '{scientific_name}'
+            AND Confidence >= {confidence}"""
+        cur.execute(sql)
+        detections = cur.fetchall()
+
+        if len(detections) == 1:
+            return self._construct_file_path(detections[0])
+        return None
+
+    def _handle_no_sound(self, status: str) -> None:
+        """Handle cases where no detection sound is found."""
+        url = f"/api/detections/{self.spec['id']}"
+        response = self.client.put(url, data={"sound_reference": status})
+        if response.status_code != 200:
+            log.error(
+                f"Failed to update detection: {response.status_code} {response.text}"
+            )
+
+    def _handle_sound(self, filepath: str) -> str:
+        """Handle the case where a sound file is found."""
+        with open(filepath, "rb") as f:
+            files = {"sound": (os.path.basename(filepath), f, "audio/mpeg")}
+            url = f"/api/detections/{self.spec['id']}/sound/"
+            response = self.client.post(url, files=files)
+
+        if response.status_code != 201:
+            log.error(
+                f"Failed to upload sound file: {response.status_code} {response.text}"
+            )
+
+    @staticmethod
+    def _construct_file_path(detection: tuple[str]) -> str:
+        """Construct the file path for the detection file."""
+        date, com_name, file_name = detection
+        com_name = com_name.replace(" ", "_").replace("'", "")
+        return f"{HOME_DIR}/BirdSongs/Extracted/By_Date/{date}/{com_name}/{file_name}"

--- a/scripts/luistervink_task_check.sh
+++ b/scripts/luistervink_task_check.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 # Load configuration
 config_file=/etc/birdnet/birdnet.conf

--- a/scripts/luistervink_task_check.sh
+++ b/scripts/luistervink_task_check.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-set -x
 
-# Load configuration
 config_file=/etc/birdnet/birdnet.conf
 if [ -f ${config_file} ];then
     source ${config_file}

--- a/scripts/luistervink_task_check.sh
+++ b/scripts/luistervink_task_check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Load configuration
+config_file=/etc/birdnet/birdnet.conf
+if [ -f ${config_file} ];then
+    source ${config_file}
+else
+    echo "Unable to find a configuration file. Please make sure that $config_file exists."
+    exit 1
+fi
+
+export PYTHON_VIRTUAL_ENV="$HOME/BirdNET-Pi/birdnet/bin/python3"
+
+# Check LUISTERVINK_ENABLE_TASK_PROCESSOR and run Python script if true
+if [[ "${LUISTERVINK_ENABLE_TASK_PROCESSOR,,}" == "true" ]]; then
+    $PYTHON_VIRTUAL_ENV /usr/local/bin/luistervink_tasks.py
+else
+    echo "LUISTERVINK_ENABLE_TASK_PROCESSOR is not enabled, skipping task processing."
+fi

--- a/scripts/luistervink_tasks.py
+++ b/scripts/luistervink_tasks.py
@@ -3,8 +3,13 @@ from luistervink.client import LuistervinkClient
 from luistervink.dto import Task
 from luistervink.handler import DetectionSoundHandler
 from utils.helpers import get_settings
+import sys
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('task_processor')
+formatter = logging.Formatter("[%(name)s][%(levelname)s] %(message)s")
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setFormatter(formatter)
+log.addHandler(handler)
 
 
 class TasksProcessor:
@@ -15,6 +20,7 @@ class TasksProcessor:
     def process_tasks(self):
         """Process tasks from the Luistervink API."""
         tasks = self.collect()
+        log.info(f'{len(tasks)} task{"s" if len(tasks) == 1 else ""} collected')
         for task in tasks:
             log.info(
                 f"[Luistervink] Processing task: {task.type} with spec: {task.spec}"

--- a/scripts/luistervink_tasks.py
+++ b/scripts/luistervink_tasks.py
@@ -1,0 +1,52 @@
+import logging
+from luistervink.client import LuistervinkClient
+from luistervink.dto import Task
+from luistervink.handler import DetectionSoundHandler
+from utils.helpers import get_settings
+
+log = logging.getLogger(__name__)
+
+
+class TasksProcessor:
+    def __init__(self, client: LuistervinkClient):
+        self.client = client
+        self.handlers = [DetectionSoundHandler]
+
+    def process_tasks(self):
+        """Process tasks from the Luistervink API."""
+        tasks = self.collect()
+        for task in tasks:
+            log.info(
+                f"[Luistervink] Processing task: {task.type} with spec: {task.spec}"
+            )
+            try:
+                self.process(task)
+                log.info(f"[Luistervink] Task processed successfully")
+            except Exception as e:
+                log.error(f"[Luistervink] Failed to process task: {task.type}: {e}")
+
+    def process(self, task: Task):
+        for handler in self.handlers:
+            if handler.type == task.type:
+                return handler(self.client, task.spec).handle()
+        log.warning(f"[Luistervink] No handler found for task type: {task.type}")
+
+    def collect(self) -> list[Task]:
+        """Collect tasks from the Luistervink API."""
+        try:
+            response = self.client.get("tasks")
+            if response.status_code != 200:
+                log.error(
+                    f"[Luistervink] Failed to fetch tasks: {response.status_code} {response.text}"
+                )
+            tasks = response.json()
+            return [Task(**task) for task in tasks]
+        except Exception as e:
+            log.error(f"[Luistervink] Error collecting tasks: {e}")
+            return []
+
+
+if __name__ == "__main__":
+    client = LuistervinkClient(get_settings("birdnet.conf"))
+    processor = TasksProcessor(client)
+    processor.process_tasks()

--- a/scripts/luistervink_tasks.py
+++ b/scripts/luistervink_tasks.py
@@ -47,6 +47,6 @@ class TasksProcessor:
 
 
 if __name__ == "__main__":
-    client = LuistervinkClient(get_settings("birdnet.conf"))
+    client = LuistervinkClient(get_settings())
     processor = TasksProcessor(client)
     processor.process_tasks()

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -108,6 +108,10 @@ if ! grep -E '^MAX_FILES_SPECIES=' /etc/birdnet/birdnet.conf &>/dev/null;then
   echo "MAX_FILES_SPECIES=\"0\"" >> /etc/birdnet/birdnet.conf
 fi
 
+if ! grep -E '^LUISTERVINK_ENABLE_TASK_PROCESSOR=' /etc/birdnet/birdnet.conf &>/dev/null;then
+  echo "LUISTERVINK_ENABLE_TASK_PROCESSOR=true" >> /etc/birdnet/birdnet.conf
+fi
+
 if ! grep -E '^RARE_SPECIES_THRESHOLD=' /etc/birdnet/birdnet.conf &>/dev/null;then
   echo '## RARE_SPECIES_THRESHOLD defines after how many days a species is considered as rare and highlighted on overview page' >> /etc/birdnet/birdnet.conf
   echo "RARE_SPECIES_THRESHOLD=\"30\"" >> /etc/birdnet/birdnet.conf

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -197,7 +197,7 @@ if [ -L /usr/local/bin/birdnet_analysis.sh ];then
 fi
 
 # Clean state and update cron if all scripts are not installed
-if [ "$(grep -o "#birdnet" /etc/crontab | wc -l)" -lt 5 ]; then
+if [ "$(grep -o "#birdnet" /etc/crontab | wc -l)" -lt 6 ]; then
   sudo sed -i '/birdnet/,+1d' /etc/crontab
   sed "s/\$USER/$USER/g" "$HOME"/BirdNET-Pi/templates/cleanup.cron >> /etc/crontab
   sed "s/\$USER/$USER/g" "$HOME"/BirdNET-Pi/templates/weekly_report.cron >> /etc/crontab

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -201,6 +201,7 @@ if [ "$(grep -o "#birdnet" /etc/crontab | wc -l)" -lt 5 ]; then
   sudo sed -i '/birdnet/,+1d' /etc/crontab
   sed "s/\$USER/$USER/g" "$HOME"/BirdNET-Pi/templates/cleanup.cron >> /etc/crontab
   sed "s/\$USER/$USER/g" "$HOME"/BirdNET-Pi/templates/weekly_report.cron >> /etc/crontab
+  sed "s/\$USER/$USER/g" "$HOME"/BirdNET-Pi/templates/luistervink.cron >> /etc/crontab
 fi
 
 set +x

--- a/scripts/utils/helpers.py
+++ b/scripts/utils/helpers.py
@@ -13,6 +13,7 @@ _settings = None
 DB_PATH = os.path.expanduser('~/BirdNET-Pi/scripts/birds.db')
 ANALYZING_NOW = os.path.expanduser('~/BirdSongs/StreamData/analyzing_now.txt')
 FONT_DIR = os.path.expanduser('~/BirdNET-Pi/homepage/static')
+HOME_DIR = os.path.expanduser('~')
 
 
 def get_font():

--- a/templates/luistervink.cron
+++ b/templates/luistervink.cron
@@ -1,0 +1,2 @@
+#birdnet
+2-59/10 * * * * $USER /usr/local/bin/luistervink_task_check.sh >/dev/null 2>&1

--- a/templates/luistervink.cron
+++ b/templates/luistervink.cron
@@ -1,2 +1,2 @@
 #birdnet
-2-59/10 * * * * $USER /usr/local/bin/luistervink_task_check.sh >/dev/null 2>&1
+2-59/10 * * * * $USER sleep $(shuf -i 0-9 -n 1)m; /usr/local/bin/luistervink_task_check.sh >/dev/null 2>&1

--- a/templates/luistervink.cron
+++ b/templates/luistervink.cron
@@ -1,2 +1,2 @@
 #birdnet
-2-59/10 * * * * $USER sleep $(shuf -i 0-9 -n 1)m; /usr/local/bin/luistervink_task_check.sh >/dev/null 2>&1
+*/10 * * * * $USER sleep $(shuf -i 0-9 -n 1)m; /usr/local/bin/luistervink_task_check.sh 2>&1 | systemd-cat -t luistervink


### PR DESCRIPTION
Add Luistervink task processor: a script which collects tasks for the device from the server and then attempts to process these tasks.

Processing is very forgiving to avoid blocking devices if a task fails.

Added a config option to disable the task processor for a device, e.g. in case of low bandwidth.

Currently one processor is enabled: to process sound requests. Other processors can be easily by extending the `BaseHandler` class.

The processor will run on a cron basis, for now set to every 10 mins with an offset of 2 mins: so at :12, :22, :32 etc. This is done to avoid overloading the device with tasks triggered at the same time (other crons start at :00, :05 etc).

This branch is currently being tested on my Luistervink.